### PR TITLE
[r2.16-rocm] CI doesn't handle UB22 so symlink should still point to UB20 dockerfile

### DIFF
--- a/tensorflow_serving/tools/docker/Dockerfile.devel-rocm
+++ b/tensorflow_serving/tools/docker/Dockerfile.devel-rocm
@@ -1,1 +1,1 @@
-Dockerfile.ub22.devel-rocm
+Dockerfile.ub20.devel-rocm

--- a/tensorflow_serving/tools/docker/Dockerfile.rocm
+++ b/tensorflow_serving/tools/docker/Dockerfile.rocm
@@ -1,1 +1,1 @@
-Dockerfile.ub22.rocm
+Dockerfile.ub20.rocm


### PR DESCRIPTION
To fix https://ontrack-internal.amd.com/browse/SWDEV-481811

CI doesn't handle UB22 so symlink should still point to UB20 dockerfile