### PR TITLE
Adjust some build dependency pins for 2.18

### DIFF
--- a/tensorflow_serving/tools/docker/devel.requirements.txt
+++ b/tensorflow_serving/tools/docker/devel.requirements.txt
@@ -8,13 +8,10 @@ absl-py ~= 1.0.0
 astunparse ~= 1.6.3
 flatbuffers ~= 24.3.25
 google_pasta ~= 0.2
-h5py ~= 3.10.0 # Earliest version for Python 3.12
-ml_dtypes ~= 0.3.1
-# TODO(b/262592253): Support older versions of NumPy for Python 3.10 and lower
-# to support TFX. Remove when Apache Beam upgrades to newer NumPy.
-numpy ~= 1.22.0; python_version < '3.11'
-numpy ~= 1.23.2; python_version == '3.11' # Earliest version for Python 3.11
-numpy ~= 1.26.0; python_version >= '3.12' # Earliest version for Python 3.12
+h5py ~= 3.11.0 # Earliest version for Python 3.12
+ml_dtypes ~= 0.4.0
+# Note that numpy 2.1.0 does not support python 3.9
+numpy >= 2.0.0, < 2.2.0
 opt_einsum ~= 3.3.0
 packaging ~= 23.2
 protobuf ~= 3.20.3
@@ -22,7 +19,7 @@ six ~= 1.16.0
 termcolor ~= 2.1.1
 typing_extensions ~= 4.8.0
 wheel ~= 0.41.2
-setuptools >= 68.2.2
+setuptools >= 70.0.0
 wrapt ~= 1.14.1
 # We need to pin the gast dependency exactly
 gast == 0.4.0
@@ -32,14 +29,12 @@ gast == 0.4.0
 # For release jobs, we will pin these on the release branch
 # Note that the CACHEBUSTER variable, set in the CI builds, will force these to
 # be the latest version.
-keras >= 3.2.0.dev
-tensorboard ~= 2.17.0
+keras >= 3.5.0
+tensorboard ~= 2.18.0
 # Test dependencies
 grpcio ~= 1.59.0 # Earliest version for Python 3.12
 portpicker ~= 1.6.0
-scipy ~= 1.7.2; python_version < '3.11'
-scipy ~= 1.9.2; python_version == '3.11' # Earliest version for Python 3.11
-scipy ~= 1.11.3; python_version >= '3.12' # Earliest version for Python 3.12
+scipy >= 1.13.0
 # Required for TFLite import from JAX tests
 jax ~= 0.4.1; python_version <= '3.11'
 jaxlib ~= 0.4.1; python_version <= '3.11' # Earliest version for Python 3.11
@@ -55,4 +50,4 @@ mock
 future>=0.17.1
 
 # For using Python 3.11 with Bazel 6 (b/286090018)
-lit ~= 16.0.5.post0
+lit ~= 17.0.2


### PR DESCRIPTION
Collected from:
- https://github.com/ROCm/tensorflow-upstream/blob/r2.18-rocm-enhanced/tensorflow/tools/tf_sig_build_dockerfiles/devel.requirements.txt
- https://github.com/tensorflow/tensorflow/blob/r2.18/ci/official/requirements_updater/requirements.in
